### PR TITLE
chore: add runners for deployment and base image builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ PORT=3001
 TEST_REPO_URL=https://github.com/nully0x/test-repo
 TEST_REPO_BRANCH=main
 TEST_REPO_PATH=tests
+BASE_URL=

--- a/.github/workflows/staging-build-base-image.yml
+++ b/.github/workflows/staging-build-base-image.yml
@@ -1,0 +1,48 @@
+name: Build Base Images
+
+on:
+  workflow_dispatch: # Manual trigger
+  push:
+    paths:
+      - "baseImages/**"
+    branches:
+      - main
+
+jobs:
+  build-base-images:
+    name: Build Base Images on Droplet
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - { name: "rust", tag: "rs-base", path: "baseImages/rust" }
+          - {
+              name: "typescript",
+              tag: "ts-base",
+              path: "baseImages/typescript",
+            }
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.STAGING_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.STAGING_DROPLET_IP }} >> ~/.ssh/known_hosts
+
+      # Create directory and copy Dockerfile
+      - name: Copy Dockerfile to Droplet
+        run: |
+          ssh ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }} "mkdir -p ~/base-images/${{ matrix.image.name }}"
+          scp ${{ matrix.image.path }}/Dockerfile ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }}:~/base-images/${{ matrix.image.name }}/Dockerfile
+
+      # Build the image on the droplet
+      - name: Build Base Image
+        run: |
+          ssh ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }} << 'EOF'
+            cd ~/base-images/${{ matrix.image.name }}
+            docker build -t ${{ matrix.image.tag }}:latest .
+          EOF

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to DigitalOcean
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Build and Deploy Node.js App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.STAGING_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.STAGING_DROPLET_IP }} >> ~/.ssh/known_hosts
+
+      - name: Install Dependencies and Build
+        run: |
+          yarn install
+          yarn build
+          ls dist  # Debug: Check if dist directory exists and its contents
+
+      # Create necessary directories first
+      - name: Create Remote Directories
+        run: |
+          ssh ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }} "mkdir -p ~/node-app/dist"
+
+      # Then copy files
+      - name: Copy Built Files to Droplet
+        run: |
+          scp -r dist/* ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }}:~/node-app/dist/
+          scp package.json ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }}:~/node-app/
+          scp yarn.lock ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }}:~/node-app/
+
+      - name: Set Up .env File
+        run: |
+          ssh ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }} "echo '${{ secrets.STAGING_RUNNER_SECRET_FILE }}' > ~/node-app/.env"
+
+      - name: Install Dependencies and Start App
+        run: |
+          ssh ${{ secrets.STAGING_DROPLET_USER }}@${{ secrets.STAGING_DROPLET_IP }} << 'EOF'
+          cd ~/node-app
+          yarn install --production
+          ls dist  # Debug: Check if dist directory exists on server
+
+          if pm2 list | grep -q node-app; then
+            echo "Restarting existing app..."
+            pm2 restart node-app
+          else
+            echo "Starting new app..."
+            pm2 start dist/server.js --name node-app
+          fi
+          pm2 save
+          EOF


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automate deployment and building of base Docker images for our runners directly on the DigitalOcean droplet. The workflow builds two essential base images:
- `ts-base`: TypeScript runner base image using Bun runtime
- `rs-base`: Rust runner base image using Rust 1.81.0

## Changes
- Added `.github/workflows/build-base-images.yml` workflow file
- Configured SSH-based deployment to build images on the droplet
- Set up matrix build strategy for parallel image building
-  update env example to include BASE_URL

## Workflow Details
The workflow triggers:
- On manual dispatch (workflow_dispatch)
- When changes are pushed to baseImages directory in main branch

For each base image, the workflow:
1. Creates necessary directories on the droplet
2. Copies the Dockerfile to the droplet
3. Builds the image locally on the droplet

## Required Secrets
The workflow requires these GitHub secrets:
- `STAGING_SSH_PRIVATE_KEY`- This is the private key of the machine the where we ssh in from. 
- `STAGIING_DROPLET_IP` - the droplet output from terraform run
- `STAGING_DROPLET_USER` - the droplet user, usually root for staging
- `STAGING_RUNNER_SECRET_FILE` - This is env variables for the test-runner 

## Testing
- [x] Manually triggered workflow successfully
- [x] Base images build correctly
- [x] Images are accessible on the droplet

## Next Steps
- Monitor image build times and optimize if necessary
- Consider adding health checks to the base images
- Plan for version tagging strategy
