### PR TITLE
Add python runner

### DIFF
--- a/.github/workflows/staging-build-base-image.yml
+++ b/.github/workflows/staging-build-base-image.yml
@@ -21,6 +21,7 @@ jobs:
               tag: "ts-base",
               path: "baseImages/typescript",
             }
+          - { name: "python", tag: "py-base", path: "baseImages/python" }
 
     steps:
       - name: Checkout Code

--- a/baseImages/python/Dockerfile
+++ b/baseImages/python/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.9-slim

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,6 +28,14 @@ export const LANGUAGE_CONFIGS: Record<string, LanguageConfig> = {
     ),
     runCommand: "/app/.hxckr/run.sh",
   },
+  python: {
+    language: "python",
+    dockerfilePath: path.join(
+      __dirname,
+      "../../supportedLanguageDockerfiles/python/Dockerfile",
+    ),
+    runCommand: "/app/.hxckr/run.sh",
+  },
   // Add other languages as needed
 };
 
@@ -37,6 +45,9 @@ export function detectLanguage(repoDir: string): string {
   }
   if (fs.existsSync(path.join(repoDir, "Cargo.toml"))) {
     return "rust";
+  }
+  if (fs.existsSync(path.join(repoDir, "requirements.txt"))) {
+    return "python";
   }
   throw new Error("Unsupported language");
 

--- a/src/utils/runner.ts
+++ b/src/utils/runner.ts
@@ -69,11 +69,15 @@ export async function runTestProcess(request: TestRunRequest): Promise<void> {
 
     // Create run.sh with modified commands
     const runScript = `#!/bin/bash
-
     set -e  # Exit on any error
 
-    # Run the tests only (they will execute the code as part of the tests)
-    bun test ./app/stage${progress.progress_details.current_step}${TestRepoManager.getTestExtension(language)}
+    # Run the tests based on the language
+        # For Python projects
+        pytest ./app/stage${progress.progress_details.current_step}${TestRepoManager.getTestExtension(language)} -v
+    else
+        # For TypeScript projects
+        bun test ./app/stage${progress.progress_details.current_step}${TestRepoManager.getTestExtension(language)}
+    fi
     `;
 
     const runScriptPath = path.join(repoDir, ".hxckr", "run.sh");
@@ -131,19 +135,34 @@ export async function runTestProcess(request: TestRunRequest): Promise<void> {
 }
 
 function isTestSuccessful(output: string): boolean {
-  // Check if all tests passed
-  const failMatch = output.match(/(\d+)\s+fail/);
-  const failCount = failMatch ? parseInt(failMatch[1]) : 0;
-  return failCount === 0;
+  if (output.includes("pytest")) {
+    // For Python tests - check for failures and errors
+    const hasFailed =
+      output.includes(" FAILED ") ||
+      output.includes("= FAILURES =") ||
+      output.includes(" ERROR ") ||
+      output.includes("!!!!!!!!!!!!!!!!!!!! Interrupted:");
+    return !hasFailed;
+  } else {
+    // For TypeScript tests (unchanged)
+    const failMatch = output.match(/(\d+)\s+fail/);
+    const failCount = failMatch ? parseInt(failMatch[1]) : 0;
+    return failCount === 0;
+  }
 }
 
 function cleanTestOutput(output: string): string {
-  // Remove the duplicate output and clean up the format
-  const testRunMatch = output.match(
-    /app\/stage\d+\.test\.ts:[\s\S]+?Ran \d+ tests across \d+ files\./,
-  );
-  if (testRunMatch) {
-    return testRunMatch[0].trim();
+  if (output.includes("pytest")) {
+    // For Python tests, return the complete test output
+    return output.trim();
+  } else {
+    // Handle TypeScript test output (unchanged)
+    const testRunMatch = output.match(
+      /app\/stage\d+\.test\.ts:[\s\S]+?Ran \d+ tests across \d+ files\./,
+    );
+    if (testRunMatch) {
+      return testRunMatch[0].trim();
+    }
   }
   return output.trim();
 }

--- a/src/utils/runner.ts
+++ b/src/utils/runner.ts
@@ -72,6 +72,7 @@ export async function runTestProcess(request: TestRunRequest): Promise<void> {
     set -e  # Exit on any error
 
     # Run the tests based on the language
+    if [ -f "requirements.txt" ]; then
         # For Python projects
         pytest ./app/stage${progress.progress_details.current_step}${TestRepoManager.getTestExtension(language)} -v
     else

--- a/supportedLanguageDockerfiles/python/Dockerfile
+++ b/supportedLanguageDockerfiles/python/Dockerfile
@@ -1,0 +1,17 @@
+FROM py-base
+
+WORKDIR /app
+
+# Copy requirements.txt if it exists
+COPY requirements.txt* ./
+# Install pytest and any other requirements
+RUN pip install pytest \
+    && if [ -f "requirements.txt" ]; then pip install -r requirements.txt; fi
+
+# Copy the application code and tests
+COPY . .
+
+# Make the run script executable
+RUN chmod +x /app/.hxckr/run.sh
+
+CMD ["/app/.hxckr/run.sh"]


### PR DESCRIPTION
# Add Python Test Runner Support

## Changes
- Added Python test execution support alongside existing TypeScript runner
- Implemented Python-specific test file naming convention using `stage{n}_test.py`
- Added detailed pytest output handling for better error reporting
- Updated Docker configuration to handle Python dependencies

## Testing
- Tested with Python projects containing requirements.txt
- Verified test output and error reporting
- Confirmed module imports work correctly in the containerized environment

## Notes
Python tests now run in the same directory as the implementation files to ensure proper module imports.

> we should also trigger build for base images for python from actions