### PR TITLE
chore: fix stream termination and add prod action yml

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy Runner to DigitalOcean Production
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Build and Deploy Node.js App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PROD_SSH_PRIVATE_KEY }}" > ~/.ssh/nodejs_do_key
+          chmod 600 ~/.ssh/nodejs_do_key
+          ssh-keyscan -H ${{ secrets.PROD_DROPLET_IP }} >> ~/.ssh/known_hosts
+
+      - name: Install Dependencies and Build
+        run: |
+          npm install
+          npm run build
+          ls dist  # Debug: Check if dist directory exists and its contents
+
+      - name: Create Remote Directories
+        run: |
+          ssh -i ~/.ssh/nodejs_do_key ${{ secrets.PROD_DROPLET_USER }}@${{ secrets.PROD_DROPLET_IP }} "mkdir -p ~/node-app/dist"
+
+      - name: Copy Built Files to Droplet
+        run: |
+          scp -i ~/.ssh/nodejs_do_key -r dist/* ${{ secrets.PROD_DROPLET_USER }}@${{ secrets.PROD_DROPLET_IP }}:~/node-app/dist/
+          scp -i ~/.ssh/nodejs_do_key package.json ${{ secrets.PROD_DROPLET_USER }}@${{ secrets.PROD_DROPLET_IP }}:~/node-app/
+          scp -i ~/.ssh/nodejs_do_key package-lock.json ${{ secrets.PROD_DROPLET_USER }}@${{ secrets.PROD_DROPLET_IP }}:~/node-app/
+
+      - name: Set Up .env File
+        run: |
+          ssh -i ~/.ssh/nodejs_do_key ${{ secrets.PROD_DROPLET_USER }}@${{ secrets.PROD_DROPLET_IP }} "echo '${{ secrets.PROD_RUNNER_SECRET_FILE }}' > ~/node-app/.env"
+
+      - name: Install Dependencies and Start App
+        run: |
+          ssh -i ~/.ssh/nodejs_do_key ${{ secrets.PROD_DROPLET_USER }}@${{ secrets.PROD_DROPLET_IP }} << 'EOF'
+          cd ~/node-app
+          npm install --production
+          ls dist  # Debug: Check if dist directory exists on server
+
+          if pm2 list | grep -q node-app; then
+            echo "Restarting existing app..."
+            pm2 restart node-app
+          else
+            echo "Starting new app..."
+            pm2 start dist/server.js --name node-app
+          fi
+          pm2 save
+          EOF


### PR DESCRIPTION
Key changes made:
- Added explicit connection cleanup/close in the test runner process
- Changed the trigger from `push` to `release`
- Updated the name to indicate it's for production
- Changed the secrets to use PROD_ prefix instead of STAGING_
- The workflow will now only run when a new release is published on GitHub

We'll need to set up these new production secrets in the GitHub repository:
- PROD_SSH_PRIVATE_KEY
- PROD_DROPLET_IP
- PROD_DROPLET_USER
- PROD_RUNNER_SECRET_FILE

To create a release and trigger this workflow:
1. Go to your GitHub repository
2. Click on "Releases" on the right side
3. Click "Create a new release"
4. Choose a tag version (e.g., v1.0.0)
5. Fill in the release title and description
6. Click "Publish release"
