### PR TITLE
remove verbose log

### DIFF
--- a/src/utils/runScriptGenerator.ts
+++ b/src/utils/runScriptGenerator.ts
@@ -27,7 +27,7 @@ function generateCommandForLanguage(
     case "python":
       return `pytest ./app/stage${currentStep}_test.py -v`;
     case "rust":
-      return `cargo build
+      return `cargo build --quiet &&
               cargo test ${
                 testContent
                   ? `--test stage${currentStep}_test`


### PR DESCRIPTION
This PR add --quiet to builds for rust build to minimise the log output